### PR TITLE
LayerManager

### DIFF
--- a/src/engine/core/game-object.js
+++ b/src/engine/core/game-object.js
@@ -1,4 +1,5 @@
 import Color from "/src/engine/data-structure/color.js";
+import { DefaultLayer, Layer, TerrainLayer } from "/src/engine/data-structure/layer.js";
 import Matrix from "/src/engine/data-structure/matrix.js";
 import Transform from "/src/engine/data-structure/transform.js";
 import RigidBody from "/src/engine/data-structure/rigidbody.js";
@@ -19,8 +20,9 @@ export default class GameObject {
   /**
    * @constructor
    * @param {object} [options]
-   * @param {boolean} [isActive]
-   * @param {boolean} [isVisible]
+   * @param {boolean} [options.isActive]
+   * @param {boolean} [options.isVisible]
+   * @param {Layer} [options.layer]
    * @param {Color} [options.color=Random Color]
    * @param {boolean} [options.isPhysicsEnable=false]
    * @param {Transform} [options.transform]
@@ -49,6 +51,12 @@ export default class GameObject {
      * @type {boolean}
      */
     this.isActive = typeCheck(options.isActive, "boolean", true);
+    /**
+     * 객체의 레이어다.
+     *
+     * @type {Layer}
+     */
+    this.layer = typeCheck(options.layer, Layer, new DefaultLayer());
     /**
      * 물리효과를 위한 강체다.
      *
@@ -311,6 +319,15 @@ export default class GameObject {
    */
   hide() {
     this.isVisible = false;
+  }
+
+  /**
+   * 레이어를 반환한다.
+   *
+   * @return {Layer}
+   */
+  getLayer() {
+    return this.layer;
   }
 
   /**

--- a/src/engine/core/layer-manager.js
+++ b/src/engine/core/layer-manager.js
@@ -1,0 +1,69 @@
+/**
+ * 객체의 종류를 나누기 위해 레이어를 사용한다.
+ * 예를 들어, 벽이나 땅같은 객체들은 지형 레이어에 속하고,
+ * 아군이나 적은 유닛 레이어에, 화살이나 포탄, 총알 등은 투사체 레이어에 속한다.
+ * 이는 물리엔진에서 활용되어 객체가 특정 레이어에 속하는
+ * 객체의 충돌을 무시할 수 있다.
+ * LayerManager에서는 각 레이어의 상태를 관리한다.
+ */
+export default class LayerManager {
+  /**
+   * 전체 레이어의 목록을 나타낸다. 
+   * 새로운 Layer클래스를 생성하는 순간 Layer클래스의 생성자에 의해
+   * layerSet에 그 레이어가 추가된다.
+   *
+   * @type {Set} @static 
+   */
+  static layerSet = new Set();
+
+  /**
+   * map에 각 레이어별로 Set을 만들어
+   * 다른 레이어와 충돌체크가 가능한지 나타낸다.
+   *
+   * 만약 어떤 레이어의 Set에 특정 레이어의 이름이 있다면
+   * 그 레이어와 충돌체크를 진행하게 된다.
+   * 반대로 어떤 레이어의 Set에 특정 레이어의 이름이 없다면
+   * 그 레이어와 충돌체크를 진행하지 않는다.
+   *
+   * ex.
+   * a의 Set이 {'a','b','c'}라면, a레이어는 a, b, c레이어와
+   * 충돌체크를 진행하게 된다.
+   *
+   * @type {Map}
+   * @static
+   */
+  static physicsInteractionMap = new Map();
+
+  constructor() {}
+
+  /**
+   * physicsInterationMap에 모든 레이어별로 Set을 생성하고,
+   * 각 Set에 모든 레이어를 추가한다.
+   */
+  static initializePhysicsInteractionState() {
+    LayerManager.layerSet.forEach((layerName) => {
+      const layerSet = new Set(LayerManager.layerSet);
+      LayerManager.physicsInteractionMap.set(layerName, layerSet);
+    });
+  }
+
+  /**
+   * 두 레이어간 충돌체크를 할 것인지를 설정한다.
+   * isEnable이 true라면 두 레이어간 충돌체크를 활성화한다.
+   *
+   * @param {Layer} layerA - 충돌체크를 설정할 레이어
+   * @param {Layer} layerB - 충돌체크를 설정할 레이어
+   * @param {boolean} isEnable - 충돌체크의 활성화 여부
+   */
+  static setPhysicsInteration(layerClassA, layerClassB, isEnable) {
+    const layerA = layerClassA.name;
+    const layerB = layerClassB.name;
+    if (isEnable) {
+      LayerManager.physicsInteractionMap.get(layerA).add(layerB);
+      LayerManager.physicsInteractionMap.get(layerB).add(layerA);
+    } else {
+      LayerManager.physicsInteractionMap.get(layerA).delete(layerB);
+      LayerManager.physicsInteractionMap.get(layerB).delete(layerA);
+    }
+  }
+}

--- a/src/engine/core/physics-manager.js
+++ b/src/engine/core/physics-manager.js
@@ -52,7 +52,17 @@ export default class PhysicsManager {
       // 만약 충돌했을 경우 이벤트함수를 실행하고 물리효과를 적용한다.
       for (let j = i + 1; j < length; j++) {
         const other = objectList[j];
+        // 두 객체가 모두 static rigidbody일 경우에는
+        // 충돌체크를 하지 않는다.
         if (obj.rigidbody.isStatic && other.rigidbody.isStatic) {
+          continue;
+        }
+
+        // 두 객체의 레이어가 충돌체크를 하지 않는 레이어관계라면
+        // 충돌체크를 하지 않는다.
+        if (
+          obj.getLayer().canPhysicsInteractLayerWith(other.getLayer()) === false
+        ) {
           continue;
         }
         if (collisionResolver.isCollideWith(other)) {

--- a/src/engine/core/physics-manager.js
+++ b/src/engine/core/physics-manager.js
@@ -112,12 +112,14 @@ export default class PhysicsManager {
    */
   static collectPhysicsEnabledGameObjectToList(scene) {
     scene.childList.forEach((child) => {
-      if (child.isPhysicsEnable) {
-        PhysicsManager.physicsEnableGameObjectList.push(child);
-      }
+      if (child.isActive) {
+        if (child.isPhysicsEnable) {
+          PhysicsManager.physicsEnableGameObjectList.push(child);
+        }
 
-      if (child.childList.length > 0) {
-        PhysicsManager.collectPhysicsEnabledGameObjectToList(child);
+        if (child.childList.length > 0) {
+          PhysicsManager.collectPhysicsEnabledGameObjectToList(child);
+        }
       }
     });
   }

--- a/src/engine/core/resource-loader-factory.js
+++ b/src/engine/core/resource-loader-factory.js
@@ -1,0 +1,136 @@
+import ResourceManager from "/src/engine/core/resource-manager.js";
+
+import Path from "/src/engine/utils/path.js";
+/**
+ * 추상 팩토리 패턴을 사용하여 원하는 리소스를 로드하는
+ * ResourceLoader 클래스를 생성해 반환한다.
+ */
+class ResourceLoaderFactory {
+  constructor() {}
+
+  /**
+   *
+   * @param {string} path - 리소스의 경로
+   * @param {Audio|Image} Element - 리소스를 생성할 객체의 타입
+   * @param {function} callback - 리소스가 생성된 이후에 실행할 콜백함수
+   * @returns
+   */
+  static create(path, constructor, callback) {
+    if (constructor.name === "Audio") {
+      return new AudioResourceLoader(path, constructor.name, callback);
+    } else if (constructor.name === "Image") {
+      return new ImageResourceLoader(path, constructor.name, callback);
+    }
+  }
+}
+
+/**
+ * 리소스를 생성해 반환하는 추상클래스다.
+ * 이 객체를 상속받은 하위 클래스에서 구체적인 생성방법을 정의한다.
+ */
+class ResourceLoader {
+  /**
+   * 생성자명에 따른 기본 리소스명을 의미한다.
+   * 만약 리소스의 경로가 주어지지 않았다면 이 객체를 이용해
+   * 기본 리소스를 생성하게 된다.
+   *
+   * @type {object}
+   * @static
+   */
+  static defaultResourcePath = {
+    Image: "defaultSpriteImage.png",
+    Audio: "defaultSoundEffect.wav",
+  };
+
+  /**
+   * @constructor
+   * @param {string} path - 리소스의 경로
+   * @param {string} constructorName - 리소스를 생성할 생성자명
+   * @param {function} callback - 리소스가 생성된 이후에 실행할 콜백함수
+   */
+  constructor(path, constructorName, callback) {
+    this.callback = callback;
+    if (typeof path === "string") {
+      this.path = Path.convertToAbsoluteAssetPath(path);
+    } else {
+      this.path =
+        "/src/engine/assets/" +
+        ResourceLoader.defaultResourcePath[constructorName];
+    }
+  }
+
+  /**
+   * @abstract
+   *
+   * 이 클래스를 상속했다면 load()를 재정의하여
+   * 구체적인 리소스 생성방법을 정의해야한다.
+   */
+  load() {}
+}
+
+/**
+ * AudioElement를 생성해 반환한다.
+ *
+ * @extends ResourceLoader
+ */
+class AudioResourceLoader extends ResourceLoader {
+  /**
+   * @constructor
+   * @param {string} path - 리소스의 경로
+   * @param {string} constructorName - 리소스를 생성할 생성자명
+   * @param {function} callback - 리소스가 생성된 이후에 실행할 콜백함수
+   */
+  constructor(path, constructorName, callback) {
+    super(path, constructorName, callback);
+  }
+
+  /**
+   * AudioElement를 생성해 반환한다.
+   *
+   * @returns {HTMLAudioElement}
+   */
+  load() {
+    const resource = new Audio(this.path);
+    ResourceManager.addResourceCount(1);
+    resource.addEventListener("loadeddata", () => {
+      ResourceManager.onResourceLoad(1);
+      this.callback();
+    });
+    return resource;
+  }
+}
+
+/**
+ * ImageElement를 생성해 반환한다.
+ *
+ * @extends ResourceLoader
+ */
+class ImageResourceLoader extends ResourceLoader {
+  /**
+   * @constructor
+   * @param {string} path - 리소스의 경로
+   * @param {string} constructorName - 리소스를 생성할 생성자명
+   * @param {function} callback - 리소스가 생성된 이후에 실행할 콜백함수
+   */
+  constructor(path, constructorName, callback) {
+    super(path, constructorName, callback);
+  }
+
+  /**
+   * ImageElement를 생성해 반환한다.
+   * @returns {HTMLImageElement}
+   */
+  load() {
+    const resource = new Image();
+    resource.src = this.path;
+    ResourceManager.addResourceCount(1);
+    resource.addEventListener("load", () => {
+      ResourceManager.onResourceLoad(1);
+      this.callback();
+    });
+
+    return resource;
+  }
+}
+
+export default ResourceLoaderFactory;

--- a/src/engine/core/resource-manager.js
+++ b/src/engine/core/resource-manager.js
@@ -1,151 +1,22 @@
-import SceneManager from "/src/engine/core/scene-manager.js";
-import Path from "/src/engine/utils/path.js";
+import ResourceLoaderFactory from "/src/engine/core/resource-loader-factory.js";
 
 /**
- * 추상 팩토리 패턴을 사용하여 원하는 리소스를 불러오는
- * ResourceLoader 클래스를 생성해 반환한다.
- */
-class ResourceLoaderFactory {
-  constructor() {}
-
-  /**
-   *
-   * @param {string} path - 리소스의 경로
-   * @param {Audio|Image} Element - 리소스를 생성할 객체의 타입
-   * @param {function} callback - 리소스가 생성된 이후에 실행할 콜백함수
-   * @returns
-   */
-  static create(path, constructor, callback) {
-    if (constructor.name === "Audio") {
-      return new AudioResourceLoader(path, constructor.name, callback);
-    } else if (constructor.name === "Image") {
-      return new ImageResourceLoader(path, constructor.name, callback);
-    }
-  }
-}
-
-/**
- * 리소스를 생성해 반환하는 추상클래스다.
- * 이 객체를 상속받은 하위 클래스에서 구체적인 생성방법을 정의한다.
- */
-class ResourceLoader {
-  /**
-   * 생성자명에 따른 기본 리소스명을 의미한다.
-   * 만약 리소스의 경로가 주어지지 않았다면 이 객체를 이용해
-   * 기본 리소스를 생성하게 된다.
-   *
-   * @type {object}
-   * @static
-   */
-  static defaultResourcePath = {
-    Image: "defaultSpriteImage.png",
-    Audio: "defaultSoundEffect.wav",
-  };
-
-  /**
-   * @constructor
-   * @param {string} path - 리소스의 경로
-   * @param {string} constructorName - 리소스를 생성할 생성자명
-   * @param {function} callback - 리소스가 생성된 이후에 실행할 콜백함수
-   */
-  constructor(path, constructorName, callback) {
-    this.callback = callback;
-    if (typeof path === "string") {
-      this.path = Path.convertToAbsoluteAssetPath(path);
-    } else {
-      this.path =
-        "/src/engine/assets/" +
-        ResourceLoader.defaultResourcePath[constructorName];
-    }
-  }
-
-  /**
-   * @abstract
-   *
-   * 이 클래스를 상속했다면 load()를 재정의하여
-   * 구체적인 리소스 생성방법을 정의해야한다.
-   */
-  load() {}
-}
-
-/**
- * AudioElement를 생성해 반환한다.
- *
- * @extends ResourceLoader
- */
-class AudioResourceLoader extends ResourceLoader {
-  /**
-   * @constructor
-   * @param {string} path - 리소스의 경로
-   * @param {string} constructorName - 리소스를 생성할 생성자명
-   * @param {function} callback - 리소스가 생성된 이후에 실행할 콜백함수
-   */
-  constructor(path, constructorName, callback) {
-    super(path, constructorName, callback);
-  }
-
-  /**
-   * AudioElement를 생성해 반환한다.
-   * @returns {HTMLAudioElement}
-   */
-  load() {
-    const resource = new Audio(this.path);
-    resource.addEventListener("loadeddata", () => {
-      ResourceManager.onResourceLoad();
-      this.callback();
-    });
-    return resource;
-  }
-}
-
-/**
- * ImageElement를 생성해 반환한다.
- *
- * @extends ResourceLoader
- */
-class ImageResourceLoader extends ResourceLoader {
-  /**
-   * @constructor
-   * @param {string} path - 리소스의 경로
-   * @param {string} constructorName - 리소스를 생성할 생성자명
-   * @param {function} callback - 리소스가 생성된 이후에 실행할 콜백함수
-   */
-  constructor(path, constructorName, callback) {
-    super(path, constructorName, callback);
-  }
-
-  /**
-   * ImageElement를 생성해 반환한다.
-   * @returns {HTMLImageElement}
-   */
-  load() {
-    const resource = new Image();
-    resource.src = this.path;
-    resource.addEventListener("load", () => {
-      ResourceManager.onResourceLoad();
-      this.callback();
-    });
-    return resource;
-  }
-}
-
-/**
- * 비동기로 리소스를 불러와야 할 때 리소스를 생성하는 역할과
- * 모든 리소스가 로드되었는지 확인하는 역할을 맡는다.
+ * 리소스를 비동기로 로드하는 역할을 맡는다.
+ * 모든 리소스가 불러와졌다면 등록된 콜백 함수를 호출한다.
  */
 export default class ResourceManager {
   /** @type {number} @static */
   static loadedResourceCount = 0;
   /** @type {number} @static */
   static totalResourceCount = 0;
-  /** @type {boolean} @static */
-  static isRunEngineEventOccurred = false;
+  /** @type {function} @static */
+  static allResourceLoadedCallback = () => {};
 
   constructor() {}
 
   /**
    * path를 경로로 하는 리소스를 생성한다.
-   * 이 때 리소스를 생성할 객체는 Element다.
+   * 이 때 리소스는 constructor에 의해 생성된다.
    *
    * @param {string} path - 리소스의 경로
    * @param {Audio.constructor|Image.constructor} constructor - 리소스를 생성할 생성자
@@ -159,49 +30,61 @@ export default class ResourceManager {
       callback
     );
 
-    ResourceManager.addResourceCount(1);
-
     return resourceLoader.load();
   }
 
   /**
-   * 리소스 1개를 불러올 때 호출하여
-   * loadedResourceCount를 1만큼 증가시킨다.
-   * 그리고 모든 리소스가 불러와졌는지 검사한다.
+   * 로드한 리소스의 개수를 count만큼 증가시킨다.
+   *
+   * @param {number} count - 로드한 리소스의 개수
    */
-  static onResourceLoad() {
-    ResourceManager.loadedResourceCount++;
+  static onResourceLoad(count) {
+    ResourceManager.loadedResourceCount += count;
 
-    if (ResourceManager.isRunEngineEventOccurred === false) {
-      ResourceManager.checkAllResourceLoaded();
+    if (ResourceManager.isAllResourceLoaded()) {
+      ResourceManager.allResourceLoadedCallback();
+      ResourceManager.removeResourceLoadedCallback();
     }
   }
 
   /**
-   * 불러올 리소스의 총 개수를 증가시킨다.
+   * 모든 리소스가 로드되었는지를 확인한다.
    *
-   * @param {number} count - 불러올 리소스의 개수
+   * @returns {boolean}
+   */
+  static isAllResourceLoaded() {
+    return (
+      ResourceManager.loadedResourceCount === ResourceManager.totalResourceCount
+    );
+  }
+
+  /**
+   * 모든 리소스가 로드되었을 때 실행될 콜백함수를 초기화한다.
+   */
+  static removeResourceLoadedCallback() {
+    ResourceManager.allResourceLoadedCallback = () => {};
+  }
+
+  /**
+   * 로드할 리소스의 총 개수를 증가시킨다.
+   *
+   * @param {number} count - 로드할 리소스의 개수
    */
   static addResourceCount(count) {
     ResourceManager.totalResourceCount += count;
   }
 
   /**
-   * loadedResourceCount와 totalResourceCount를 비교해
-   * 값이 일치하면 runEngine 이벤트를 발생시킨다.
+   * 모든 리소스가 로드되었을 때 실행할 콜백함수를 설정한다.
+   *
+   * @param {function} callback
    */
-  static checkAllResourceLoaded() {
-    if (
-      ResourceManager.loadedResourceCount === ResourceManager.totalResourceCount
-    ) {
-      const runEngine = new Event("runEngine", { bubbles: true });
-      window.dispatchEvent(runEngine);
-      ResourceManager.isRunEngineEventOccurred = true;
-    }
+  static setAllResourceLoadedCallback(callback) {
+    ResourceManager.allResourceLoadedCallback = callback;
   }
 
   /**
-   * 불러와야할 리소스의 총 개수를 반환한다.
+   * 로드해야할 리소스의 총 개수를 반환한다.
    *
    * @returns {number}
    */
@@ -210,7 +93,7 @@ export default class ResourceManager {
   }
 
   /**
-   * 불러온 리소스의 개수를 반환한다.
+   * 로드한 리소스의 개수를 반환한다.
    *
    * @returns {number}
    */

--- a/src/engine/data-structure/layer.js
+++ b/src/engine/data-structure/layer.js
@@ -1,0 +1,76 @@
+import LayerManager from "/src/engine/core/layer-manager.js";
+
+/**
+ * Layer클래스는 객체가 어느 레이어에 속하는지를 나타내고,
+ * 물리엔진에서 이 객체가 다른 객체와 충돌했는지 판단할 때
+ * LayerManager에 명시된 상태에 따라 충돌을 무시할지 결정한다.
+ */
+class Layer {
+  /**
+   * 전체 레이어 목록에 새로운 레이어가 없다면 이 레이어를 목록에 추가하고,
+   * physicsInteractionMap에 있는 다른 레이어에 이 레이어를 추가하여
+   * 충돌체크를 진행하게 한다.
+   *
+   * @constructor
+   * @param {Layer} layerConstructor
+   */
+  constructor(layerConstructor) {
+    if (LayerManager.layerSet.has(layerConstructor.name) === false) {
+      LayerManager.physicsInteractionMap.set(
+        layerConstructor.name,
+        new Set(LayerManager.layerSet)
+      );
+      LayerManager.physicsInteractionMap.forEach((value) => {
+        value.add(layerConstructor.name);
+      });
+      LayerManager.layerSet.add(layerConstructor.name);
+    }
+  }
+
+  /**
+   * 이 레이어와 다른 레이어가 충돌체크를 할 수 있다면 true를 반환한다.
+   *
+   * @param {T} otherLayer
+   * @returns {boolean}
+   */
+  canPhysicsInteractLayerWith(otherLayer) {
+    return LayerManager.physicsInteractionMap
+      .get(this.constructor.name)
+      .has(otherLayer.constructor.name);
+  }
+}
+
+/**
+ * 기본 레이어다.
+ *
+ * @extends {Layer}
+ */
+class DefaultLayer extends Layer {
+  constructor() {
+    super(DefaultLayer);
+  }
+}
+
+/**
+ * 지형을 나타내는 레이어다.
+ *
+ * @extends {Layer}
+ */
+class TerrainLayer extends Layer {
+  constructor() {
+    super(TerrainLayer);
+  }
+}
+
+/**
+ * 캐릭터, 적, NPC 등을 나타내는 레이어다.
+ *
+ * @extends {Layer}
+ */
+class UnitLayer extends Layer {
+  constructor() {
+    super(UnitLayer);
+  }
+}
+
+export { DefaultLayer, Layer, TerrainLayer, UnitLayer };

--- a/src/engine/engine.js
+++ b/src/engine/engine.js
@@ -9,15 +9,6 @@ import {
 
 import { Timer } from "/src/engine/utils.js";
 
-window.addEventListener("runEngine", () => {
-  const engine = new Engine();
-
-  // requestAnimationFrame으로 매 프레임마다 렌더링할 수 있지만
-  // 그렇게 된다면 프레임을 변경한 효과가 드러나지 않기 때문에
-  // 어쩔 수 없이 fixedDeltaTime마다 run을 호출하는 방향으로 정했다.
-  setInterval(engine.run, 1000 * Engine.timer.fixedDeltaTime);
-});
-
 /**
  * 게임 로직을 실행하고 물리효과를 적용시키며 화면에 렌더링하는 엔진이다.
  */
@@ -49,7 +40,12 @@ export default class Engine {
     LayerManager.initializePhysicsInteractionState();
 
     // 씬을 불러온다.
-    SceneManager.changeScene(settings.scene);
+    // 씬의 모든 리소스가 로드되었을 때 엔진을 실행하는
+    // 콜백함수를 인자로 넘겨준다.
+    SceneManager.loadScene(settings.scene, () => {
+      const engine = new Engine();
+      setInterval(engine.run, 1000 * Engine.timer.fixedDeltaTime);
+    });
   }
 
   /**
@@ -79,8 +75,7 @@ export default class Engine {
     SceneManager.getCurrentScene().calculateMatrix();
 
     // 모든 오브젝트를 canvas에 그린다.
-    const alpha = Engine.timer.accumulatedTime / Engine.timer.fixedDeltaTime;
-    RenderManager.render(alpha);
+    RenderManager.render();
 
     // 삭제되길 기다리는 오브젝트가 있다면 모두 삭제한다.
     DestroyManager.destroyAll();

--- a/src/engine/engine.js
+++ b/src/engine/engine.js
@@ -4,6 +4,7 @@ import {
   RenderManager,
   PhysicsManager,
   DestroyManager,
+  LayerManager,
 } from "/src/engine/module.js";
 
 import { Timer } from "/src/engine/utils.js";
@@ -43,6 +44,9 @@ export default class Engine {
 
     // canvas의 해상도를 변경한다.
     RenderManager.changeResolution(settings.width, settings.height);
+
+    // 레이어 상태를 초기화한다.
+    LayerManager.initializePhysicsInteractionState();
 
     // 씬을 불러온다.
     SceneManager.changeScene(settings.scene);

--- a/src/engine/module.js
+++ b/src/engine/module.js
@@ -11,11 +11,13 @@
 import Color from "/src/engine/data-structure/color.js";
 import Matrix from "/src/engine/data-structure/matrix.js";
 import Vector from "/src/engine/data-structure/vector.js";
+import { DefaultLayer, Layer, TerrainLayer } from "/src/engine/data-structure/layer.js";
 
 import Circle from "/src/engine/core/circle.js";
 import DestroyManager from "/src/engine/core/destroy-manager.js";
 import GameObject from "/src/engine/core/game-object.js";
 import InputManager from "/src/engine/core/input-manager.js";
+import LayerManager from "/src/engine/core/layer-manager.js";
 import PhysicsManager from "/src/engine/core/physics-manager.js";
 import Rect from "/src/engine/core/rect.js";
 import RenderManager from "/src/engine/core/render-manager.js";
@@ -28,12 +30,16 @@ import ParticleEffect from "/src/engine/fx/particle-effect.js";
 
 export {
   Color,
+  DefaultLayer,
+  Layer,
   Matrix,
+  TerrainLayer,
   Vector,
   Circle,
   DestroyManager,
   GameObject,
   InputManager,
+  LayerManager,
   PhysicsManager,
   RenderManager,
   Rect,


### PR DESCRIPTION
`PhysicsManager` checks collision by its layer. 
Even if objects actually collide with other object, if their layers are set to not collide each other, `PhysicsManager` won't do collision check.

`ResourceManager` will call event if all resource are loaded, but if scene not contain any resource, event will not be called.
This problem is fixed by changing `SceneManager.changeScene()`.
First call `SceneManager.loadScene()` with scene constructor and callback parameter which runs engine.
If scene doesn't have any resource, scene is changed immediately.
Otherwise, callback do change scene after all resource is loaded.